### PR TITLE
Fix issue with strelka2 vcfs having n_ref_count n_alt_count n_depth values being dropped in maf conversion

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -78,6 +78,13 @@ process VCF2MAF {
   vep_path  = "/root/miniconda3/envs/vep/bin"
   vep_forks = task.cpus - 2
   basename  = input_vcf.name.replaceAll(/.gz$/, "").replaceAll(/.vcf$/, "")
+  
+  // Add vcf_tumor_id and vcf_normal_id for somatic Strelka samples
+  strelka_params = ""
+  if (meta.variant_class == "somatic" && meta.variant_caller.toLowerCase() == "strelka") {
+    strelka_params = "--vcf-tumor-id TUMOR --vcf-normal-id NORMAL"
+  }
+  
   """
   if [[ ${input_vcf} == *.gz ]]; then
     zcat ${input_vcf} > intermediate.vcf
@@ -91,7 +98,7 @@ process VCF2MAF {
     --ncbi-build ${params.ncbi_build} --max-subpop-af ${params.max_subpop_af} \
     --vep-path ${vep_path} --maf-center ${params.maf_center} \
     --tumor-id '${meta.biospecimen_id}' --vep-forks ${vep_forks} \
-    --species ${params.species}
+    --species ${params.species} ${strelka_params}
 
   grep -v '^#' intermediate.maf.raw > '${basename}.maf'
   """


### PR DESCRIPTION
This pull request introduces changes to the `VCF2MAF` process in the `main.nf` file to enhance support for somatic Strelka samples. The key updates include the addition of parameters for specifying tumor and normal sample IDs when processing somatic variants called by Strelka.

### Enhancements for Strelka Somatic Samples:

* Added logic to define `strelka_params` for somatic Strelka samples, which includes the `--vcf-tumor-id TUMOR` and `--vcf-normal-id NORMAL` parameters. This ensures proper handling of tumor and normal sample IDs during the variant annotation process. (`[main.nfR81-R87](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28R81-R87)`)
* Updated the command to include `${strelka_params}` when invoking the `vcf2maf` tool, enabling dynamic parameterization based on the variant class and caller. (`[main.nfL94-R101](diffhunk://#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28L94-R101)`)