### PR TITLE
Fix VEP `--no_stats` bug causing `substr outside of string` crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Check out the [Quickstart](#quickstart) section for example parameter values. Yo
 - **`vep_tarball`**: A tarball (ideally compressed) of the VEP cache. Default: `"s3://sage-igenomes/vep_cache/homo_sapiens_vep_107_GRCh38.tar.gz"`.
 - **`ncbi_build`**: The NCBI genome build. Passed to `--assembly` in VEP ([source](http://Jul2022.archive.ensembl.org/info/docs/tools/vep/script/vep_options.html)). Default: `"GRCh38"`.
 - **`species`**: The species identifier. Passed to `--species` in VEP ([source](http://Jul2022.archive.ensembl.org/info/docs/tools/vep/script/vep_options.html)). Default: `"homo_sapiens"`.
+- **`vep_stats_params`**: Whether to pass `--vep-stats` to `vcf2maf.pl`, which prevents it from appending `--no_stats` to the internal VEP command. `--no_stats` causes a known VEP bug ([source](https://github.com/Ensembl/ensembl-vep/issues/1013#issuecomment-874079598)) with no fix planned; the VEP team  run VEP without the option `--no_stats`. Set to `false` to restore the original `--no_stats` behaviour. Default: `true`.
 
 ## Inputs
 

--- a/main.nf
+++ b/main.nf
@@ -87,7 +87,8 @@ process VCF2MAF {
 
   // Add VEP stats parameter to pass --vep-stats to vcf2maf so it does not append --no_stats internally.
   // By default, vcf2maf.pl appends --no_stats to the VEP command unless --vep-stats is provided.
-  // vcf2maf.pl (container line 461): $vep_cmd .= " --no_stats" unless( $vep_stats );
+  // vcf2maf.pl script (dockerhub sagebionetworks/vcf2maf:107.2 container line 461)
+  // $vep_cmd .= " --no_stats" unless( $vep_stats );
   // Default --no_stats behavior causes a known Ensembl VEP issue fail with
   // "substr outside of string" in TranscriptVariationAllele.pm.
   // The Ensembl VEP team currently recommends avoiding --no_stats as a short-term workaround.

--- a/main.nf
+++ b/main.nf
@@ -84,7 +84,16 @@ process VCF2MAF {
   if (meta.variant_class == "somatic" && meta.variant_caller.toLowerCase() == "strelka") {
     strelka_params = "--vcf-tumor-id TUMOR --vcf-normal-id NORMAL"
   }
-  
+
+  // Add VEP stats parameter to pass --vep-stats to vcf2maf so it does not append --no_stats internally.
+  // By default, vcf2maf.pl appends --no_stats to the VEP command unless --vep-stats is provided.
+  // vcf2maf.pl (container line 461): $vep_cmd .= " --no_stats" unless( $vep_stats );
+  // Default --no_stats behavior causes a known Ensembl VEP issue fail with
+  // "substr outside of string" in TranscriptVariationAllele.pm.
+  // The Ensembl VEP team currently recommends avoiding --no_stats as a short-term workaround.
+  // Set params.vep_stats_params = false to suppress --vep-stats.
+  vep_stats_params = params.vep_stats_params ? "--vep-stats" : ""
+
   """
   if [[ ${input_vcf} == *.gz ]]; then
     zcat ${input_vcf} > intermediate.vcf
@@ -98,7 +107,7 @@ process VCF2MAF {
     --ncbi-build ${params.ncbi_build} --max-subpop-af ${params.max_subpop_af} \
     --vep-path ${vep_path} --maf-center ${params.maf_center} \
     --tumor-id '${meta.biospecimen_id}' --vep-forks ${vep_forks} \
-    --species ${params.species} ${strelka_params}
+    --species ${params.species} ${strelka_params} ${vep_stats_params}
 
   grep -v '^#' intermediate.maf.raw > '${basename}.maf'
   """

--- a/nextflow.config
+++ b/nextflow.config
@@ -9,6 +9,7 @@ params.maf_center 			= "Sage Bionetworks"
 params.max_subpop_af 		= 0.0005
 params.ncbi_build 			= "GRCh38"
 params.species 				= "homo_sapiens"
+params.vep_stats_params		= true  // Pass --vep-stats to vcf2maf to prevent internal --no_stats
 
 // Profiles
 profiles {


### PR DESCRIPTION
This pull request introduces changes to the `VCF2MAF` process in `main.nf` to fix a VEP crash caused by `--no_stats` being appended internally by `vcf2maf.pl`. The key update is passing `--vep-stats` to disable that behavior.

## Problem

Some runs failed during VEP annotation on Seqera with this log error:

```
STATUS: Running VEP and writing to: ./intermediate.vep.vcf
substr outside of string at /root/miniconda3/envs/vep/share/ensembl-vep-107.0-0/Bio/EnsEMBL/Variation/TranscriptVariationAllele.pm line 906, <__ANONIO__> line 31648.
Died in forked process 11783
ERROR: Failed to run the VEP annotator! Command: /root/miniconda3/envs/vep/bin/perl /root/miniconda3/envs/vep/bin/vep --species homo_sapiens --assembly GRCh38 --no_progress --no_stats --buffer_size 5000 --sift b --ccds --uniprot --hgvs --symbol --numbers --domains --gene_phenotype --canonical --protein --biotype --uniprot --tsl --variant_class --shift_hgvs 1 --check_existing --total_length --allele_number --no_escape --xref_refseq --failed 1 --vcf --flag_pick_allele --pick_order canonical,tsl,biotype,rank,ccds,length --dir vep_data/ --fasta Homo_sapiens_assembly38.fasta --format vcf --input_file intermediate.vcf --output_file ./intermediate.vep.vcf --offline --pubmed --fork 4 --polyphen b --af --af_1kg --af_gnomadg --regulatory
```

Root cause: `vcf2maf.pl` (line 461 in [docker image](https://hub.docker.com/layers/sagebionetworks/vcf2maf/107.2/images/) `sagebionetworks/vcf2maf:107.2`) always appends `--no_stats` to the internal VEP command by default:

```perl
461:    $vep_cmd .= " --no_stats" unless( $vep_stats );
```

This triggers a known VEP bug (https://github.com/Ensembl/ensembl-vep/issues/1845#issuecomment-2694993295, https://github.com/Ensembl/ensembl-vep/issues/1013#issuecomment-874079598, https://github.com/mskcc/vcf2maf/issues/302) relevant to Ensembl VEP. The Ensembl VEP team confirmed there is no fix planned and recommends not using `--no_stats`.

## Fix
Pass` --vep-stats` to vcf2maf.pl to set $vep_stats = 1 internally and suppresses the automatic` --no_stats` append.

### Changes

- Added `vep_stats_params` variable to conditionally pass `--vep-stats` to `vcf2maf.pl`, suppressing the internal `--no_stats` append ([main.nf L87-96](https://github.com/Sage-Bionetworks-Workflows/nf-vcf2maf/pull/8/changes#diff-6401496ba455b9488ffa902a6e4d7732b2c60ff2d77c5c3ef96b28a7ac7d3b28))
- Added and documented the `params.vep_stats_params = true` parameter (default on; set to `false` to restore original `--no_stats` behavior) ([nextflow.config](https://github.com/Sage-Bionetworks-Workflows/nf-vcf2maf/pull/8/changes#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4ea), [README.md](https://github.com/Sage-Bionetworks-Workflows/nf-vcf2maf/pull/8/changes#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5))