### PR TITLE
chore: add GitHub PR template, issue templates, and CI workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: Report a bug or unexpected behavior
+labels: bug
+---
+
+## Description
+
+<!-- A clear description of the bug. -->
+
+## Steps to reproduce
+
+1.
+2.
+3.
+
+## Expected behavior
+
+<!-- What should have happened? -->
+
+## Actual behavior
+
+<!-- What actually happened? Include error messages or logs. -->
+
+## Environment
+
+- Nextflow version:
+- Executor (local / AWS Batch / Tower):
+- Container engine (Docker / Singularity):
+- Pipeline version/commit:
+
+## Additional context
+
+<!-- Samplesheet, config overrides, or anything else relevant. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,21 @@
+---
+name: Feature request
+about: Suggest an improvement or new feature
+labels: enhancement
+---
+
+## Problem
+
+<!-- What problem does this feature solve? -->
+
+## Proposed solution
+
+<!-- Describe what you'd like to see added or changed. -->
+
+## Alternatives considered
+
+<!-- Any other approaches you've thought about? -->
+
+## Additional context
+
+<!-- Links, references, or examples. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,23 @@
+## Summary
+
+<!-- What does this PR do? Bullet points preferred. -->
+
+-
+
+## Changes
+
+<!-- List the files/components changed and why. -->
+
+-
+
+## Test plan
+
+- [ ] `nextflow run main.nf -stub-run` passes without errors
+- [ ] Execution output matches expected results
+
+## Notes
+
+<!-- Anything reviewers should pay special attention to, or known limitations. -->
+
+<!-- Link issues below -->
+Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,28 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  stub-run:
+    name: Nextflow stub run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Nextflow
+        uses: nf-core/setup-nextflow@v2
+        with:
+          version: "latest-stable"
+
+      - name: Run stub
+        run: |
+          nextflow run main.nf \
+            -stub-run \
+            --input tests/stub_samplesheet.csv \
+            -profile docker

--- a/tests/stub_samplesheet.csv
+++ b/tests/stub_samplesheet.csv
@@ -1,0 +1,2 @@
+synapse_id,biospecimen_id,sample_parent_id,merged_parent_id,study_id,variant_class,variant_caller,is_releasable
+syn001,SAMPLE001,syn100,syn200,STUDY001,somatic,mutect2,true


### PR DESCRIPTION
## Summary

- Adds `.github/pull_request_template.md` to standardize PR descriptions across all future contributions
- Adds bug report and feature request issue templates
- Adds CI workflow that runs `nextflow run main.nf -stub-run` on every PR to `main`
- Adds `tests/stub_samplesheet.csv` as a minimal samplesheet for the CI stub run

## Notes

This is a preparatory PR ahead of the modularization refactor (#10–#13). Having CI in place means each subsequent PR gets automatic syntax/DAG validation.