### PR TITLE
fix: resolve Nextflow DSL2 syntax errors breaking CI

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -59,7 +59,7 @@ process VCF2MAF {
   cpus   6
   memory { 64.GB * task.attempt }
 
-  errorStrategy = 'retry'
+  errorStrategy 'retry'
   maxRetries 3
 
   afterScript "rm -f intermediate*"
@@ -146,7 +146,7 @@ process MERGE_MAFS {
 
   memory { 16.GB * task.attempt }
 
-  errorStrategy = 'retry'
+  errorStrategy 'retry'
   maxRetries 3
 
   input:

--- a/nextflow.config
+++ b/nextflow.config
@@ -16,7 +16,6 @@ profiles {
 
     docker {
         docker.enabled         = true
-        docker.userEmulation   = true
         singularity.enabled    = false
         podman.enabled         = false
         shifter.enabled        = false


### PR DESCRIPTION
## Summary

- Remove deprecated `docker.userEmulation` from `nextflow.config` (removed in Nextflow 26.x)
- Fix invalid `errorStrategy = 'retry'` syntax → `errorStrategy 'retry'` in `VCF2MAF` and `MERGE_MAFS` processes

## Changes

- `nextflow.config`: remove `docker.userEmulation = true`
- `main.nf`: fix `errorStrategy` assignment syntax (×2)

## Test plan

- [ ] CI `nextflow run main.nf -stub-run` passes

## Notes

These bugs were present in `main` before the CI workflow was added. The CI immediately surfaced them.

Closes #15